### PR TITLE
Allow concurrent query execution and retry handling for SPARQL extraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,6 +309,24 @@ The following environment variables can be used to configure schema loading:
 - `VARIABLE_PROPERTY`: Override the default variable property predicate (only used when `use_schema=False` or as fallback)
 - `MISSING_DATA_NOTATION`: Custom notation for missing data
 
+The following environment variables configure the reliability of the requests that are posted
+to the SPARQL endpoint:
+
+- `SPARQL_TIMEOUT`: The number of seconds that a request may take before it is considered to
+  have failed (default: `60`)
+- `SPARQL_MAX_RETRIES`: The maximum number of times that a failed request is retried, with an
+  exponentially increasing delay between attempts (default: `3`). A request is only retried
+  when it could not reach the endpoint at all (a connection error or a timeout) or when the
+  endpoint reported a server error (a 5xx status code); a client error (a 4xx status code) is
+  not retried, as the request itself is at fault. Once the retries are exhausted for a
+  variable of a `single_column` extraction, that variable is skipped and reported, rather than
+  aborting the rest of the extraction.
+- `SPARQL_MAX_CONCURRENCY`: The maximum number of `single_column` queries that may be posted
+  at once (default: `1`, i.e. sequential). Raising this lets an algorithm collect several
+  variables in parallel, which is worthwhile since posting a query is mostly a matter of
+  waiting on the endpoint's response; an endpoint that itself limits the number of concurrent
+  connections is expected to simply queue up any requests beyond that limit rather than fail.
+
 The various functions are available through `pip install` for debugging and testing purposes.
 The library can be installed as follows:
 
@@ -333,6 +351,8 @@ tests/
 │   ├── test_query_execution.py           # Tests that execute the queries on a synthetic graph
 │   ├── test_fallback_query_execution.py  # Tests that execute the queries without the schema
 │   ├── test_schema_contract.py           # Tests every variable of the schema and its snapshot
+│   ├── test_sparql_client_retries.py     # Tests the timeout and retry behaviour of post_sparql_query
+│   ├── test_concurrent_collection.py     # Tests concurrent single-column queries and failure isolation
 │   └── snapshots/                        # Golden snapshot of every variable's predicate path
 ├── integration/                          # Integration tests
 │   └── test_vantage6_integration.py      # Data stratification workflows

--- a/README.md
+++ b/README.md
@@ -318,9 +318,11 @@ to the SPARQL endpoint:
   exponentially increasing delay between attempts (default: `3`). A request is only retried
   when it could not reach the endpoint at all (a connection error or a timeout) or when the
   endpoint reported a server error (a 5xx status code); a client error (a 4xx status code) is
-  not retried, as the request itself is at fault. Once the retries are exhausted for a
-  variable of a `single_column` extraction, that variable is skipped and reported, rather than
-  aborting the rest of the extraction.
+  not retried, as the request itself is at fault, and is raised immediately instead. Once the
+  retries are exhausted for a variable of a `single_column` extraction, that variable is
+  skipped and reported, rather than aborting the rest of the extraction; a variable that the
+  endpoint rejects outright (a 4xx status code) is not a transient failure, however, and
+  aborts the whole extraction immediately instead of being skipped.
 - `SPARQL_MAX_CONCURRENCY`: The maximum number of `single_column` queries that may be posted
   at once (default: `1`, i.e. sequential). Raising this lets an algorithm collect several
   variables in parallel, which is worthwhile since posting a query is mostly a matter of

--- a/src/vantage6_strongaya_rdf/collect_sparql_data.py
+++ b/src/vantage6_strongaya_rdf/collect_sparql_data.py
@@ -4,6 +4,7 @@ RDF/SPARQL Data Collection Functions
 
 File organisation:
 - Query template loading (_load_query_template)
+- Concurrent query execution (_execute_concurrently)
 - Query processing functionalities (_process_variable_query)
 - Data collection function (collect_sparql_data)
 ------------------------------------------------------------------------------
@@ -12,8 +13,10 @@ File organisation:
 import pandas as pd
 import re
 
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from functools import partial
 from importlib import resources
-from typing import List, Optional, Tuple, Union
+from typing import Callable, Iterator, List, Optional, Sequence, Tuple, TypeVar, Union
 
 from vantage6.algorithm.tools.exceptions import (
     UserInputError,
@@ -235,6 +238,63 @@ def _load_query_template(query_name: str) -> str:
         return ""
 
 
+# The type of the result that a task yields; kept generic so that the helper below can
+# be reused by any strategy that processes a list of independent items, rather than
+# being tied to the DataFrame that the single-column query happens to produce
+_TaskResult = TypeVar("_TaskResult")
+
+
+def _execute_concurrently(
+    tasks: Sequence[Tuple[str, Callable[[], _TaskResult]]],
+    max_concurrency: int,
+) -> Iterator[Tuple[str, Optional[_TaskResult], Optional[Exception]]]:
+    """
+    Execute a list of labelled tasks, yielding each result as soon as it completes.
+
+    A concurrency of 1 (or less) runs the tasks one after another, in the order that
+    they were given, which keeps the default behaviour unchanged; a higher concurrency
+    runs them in a thread pool instead, which is worthwhile since each task merely
+    waits on an HTTP response rather than doing CPU-bound work. Any exception that a
+    task raises is caught and yielded alongside its label rather than propagated, so
+    that the failure of one task does not keep the results of the others from being
+    processed.
+
+    Args:
+        tasks (Sequence[Tuple[str, Callable[[], _TaskResult]]]): The tasks to execute,
+                                                                  each given as a label
+                                                                  (used for logging and
+                                                                  for reporting which
+                                                                  task a result or
+                                                                  failure belongs to)
+                                                                  and the callable that
+                                                                  performs the task
+                                                                  itself.
+        max_concurrency (int): The maximum number of tasks that may run at the same
+                               time.
+
+    Yields:
+        Tuple[str, Optional[_TaskResult], Optional[Exception]]: The label of the task,
+        its result (or None if it failed) and the exception that it raised (or None if
+        it succeeded).
+    """
+    if max_concurrency <= 1 or len(tasks) <= 1:
+        for label, task in tasks:
+            try:
+                yield label, task(), None
+            except Exception as e:
+                yield label, None, e
+        return
+
+    with ThreadPoolExecutor(max_workers=max_concurrency) as executor:
+        future_to_label = {executor.submit(task): label for label, task in tasks}
+        for future in as_completed(future_to_label):
+            label = future_to_label[future]
+            try:
+                yield label, future.result(), None
+            except Exception as e:
+                yield label, None, e
+
+
 def _build_prefix_declarations(schema: Optional[dict] = None) -> str:
     """
     Compose the PREFIX declarations of a SPARQL query.
@@ -410,9 +470,14 @@ def _process_variable_query(
         )
 
     safe_log("info", f"Posting SPARQL query for {variable}.")
-    result = post_sparql_query(endpoint=endpoint, query=query)
+    result = post_sparql_query(
+        endpoint=endpoint, query=query, log_label=f"Query for {variable}"
+    )
 
     if result:
+        safe_log(
+            "info", f"Query for {variable} completed and returned {len(result)} row(s)."
+        )
         result_df = _assign_patient_id(pd.DataFrame(result), variable)
 
         # Handle subClass column name variations
@@ -421,6 +486,7 @@ def _process_variable_query(
 
         return clean_null_values(extract_subclass_info(result_df, variable))
     else:
+        safe_log("info", f"Query for {variable} completed and returned no rows.")
         return pd.DataFrame(columns=["patient_id", variable])
 
 
@@ -548,10 +614,24 @@ def _process_multi_column_query(
         )
 
     safe_log("info", f"Posting multi-column SPARQL query for {var1} and {var2}.")
-    result = post_sparql_query(endpoint=endpoint, query=query)
+    result = post_sparql_query(
+        endpoint=endpoint,
+        query=query,
+        log_label=f"Multi-column query for {var1} and {var2}",
+    )
 
     if not result:
+        safe_log(
+            "info",
+            f"Multi-column query for {var1} and {var2} completed and returned no rows.",
+        )
         return pd.DataFrame(columns=["patient_id", var1, var2])
+
+    safe_log(
+        "info",
+        f"Multi-column query for {var1} and {var2} completed and returned "
+        f"{len(result)} row(s).",
+    )
 
     result_df = _assign_patient_id(pd.DataFrame(result), f"{var1} and {var2}")
 
@@ -602,7 +682,8 @@ def collect_sparql_data(
         variables_to_extract (List[str]): List of variables to extract; either the schema's
                                           variable names or their class codes.
         query_type (str, optional): The type of query to execute. Supports 'single_column' and 'multi_column'.
-                                    Defaults to 'single_column'.
+                                    Defaults to 'single_column'. The queries of a 'single_column'
+                                    extraction may be run concurrently; see SPARQL_MAX_CONCURRENCY below.
         endpoint (str, optional): The SPARQL endpoint URL.
                                   An endpoint specified in the environment variables will be prioritised.
                                   Defaults to "http://localhost:7200/repositories/userRepo".
@@ -622,6 +703,17 @@ def collect_sparql_data(
     Returns:
         pd.DataFrame: A combined DataFrame containing all retrieved data,
         with 'patient_id' as the index column and each variable as a separate column.
+
+    Note:
+        A handful of environment variables tune how a query is posted, rather than
+        being arguments of this function, as they concern the endpoint's reliability
+        rather than the data that is requested: SPARQL_TIMEOUT (the number of seconds
+        that a request may take, 60 by default), SPARQL_MAX_RETRIES (the number of
+        times a failed request is retried, 3 by default) and SPARQL_MAX_CONCURRENCY
+        (the number of 'single_column' queries that may be posted at once, 1 - i.e.
+        sequential - by default). A variable whose query keeps failing after these
+        retries are exhausted is skipped, and reported as such, so that it does not
+        keep the rest of a 'single_column' extraction from being collected.
     """
     # Retrieve environment variables - prioritise them over defaults as local setups might e.g. have different endpoints
     endpoint = get_env_var("SPARQL_ENDPOINT", endpoint)
@@ -663,28 +755,71 @@ def collect_sparql_data(
 
         intermediate_df = pd.DataFrame(columns=["patient_id", "sub_class", "value"])
 
-        for variable in variables_to_extract:
-            try:
-                result_df = _process_variable_query(
+        # A triplestore may accept several concurrent queries and simply queue up any
+        # that exceed its own capacity, which is why this defaults to sequential
+        # (1) rather than to a specific higher number; a node operator that knows the
+        # endpoint can take more can raise it through the environment
+        max_concurrency = get_env_var("SPARQL_MAX_CONCURRENCY", 1, as_type="int")
+        if max_concurrency < 1:
+            safe_log(
+                "warn",
+                f"SPARQL_MAX_CONCURRENCY of {max_concurrency} is not valid; using 1 "
+                f"(sequential) instead.",
+            )
+            max_concurrency = 1
+
+        tasks = [
+            (
+                variable,
+                partial(
+                    _process_variable_query,
                     endpoint,
                     query_template,
                     variable,
                     variable_property,
                     schema,
                     use_schema,
+                ),
+            )
+            for variable in variables_to_extract
+        ]
+
+        failed_variables = []
+        for variable, result_df, error in _execute_concurrently(tasks, max_concurrency):
+            if error is not None:
+                failed_variables.append(variable)
+                safe_log(
+                    "error",
+                    f"Query for {variable} failed and will be skipped, the rest of "
+                    f"the extraction continues without it: {error}",
                 )
-                if not result_df.empty:
-                    if intermediate_df.empty:
-                        intermediate_df = result_df
-                    else:
-                        intermediate_df = pd.merge(
-                            intermediate_df,
-                            result_df,
-                            on="patient_id",
-                            how="outer",
-                        )
-            except Exception as e:
-                raise AlgorithmError(f"Error processing {variable}: {e}")
+                continue
+
+            # A result is only ever None alongside an error, which is handled (and
+            # skipped) above, so a result reaching this point is never None
+            assert result_df is not None
+
+            # Merging every result into the accumulated DataFrame as soon as it
+            # arrives, rather than collecting every result first and merging them
+            # afterwards, keeps the peak memory usage bound to the accumulated
+            # result and the single largest query result, regardless of how many
+            # variables are extracted
+            if not result_df.empty:
+                if intermediate_df.empty:
+                    intermediate_df = result_df
+                else:
+                    intermediate_df = pd.merge(
+                        intermediate_df,
+                        result_df,
+                        on="patient_id",
+                        how="outer",
+                    )
+
+        if failed_variables and len(failed_variables) == len(variables_to_extract):
+            raise AlgorithmError(
+                f"Query failed for every requested variable: "
+                f"{', '.join(failed_variables)}."
+            )
 
     elif query_type == "multi_column":
         query_template = _prepare_query_template(

--- a/src/vantage6_strongaya_rdf/collect_sparql_data.py
+++ b/src/vantage6_strongaya_rdf/collect_sparql_data.py
@@ -711,9 +711,12 @@ def collect_sparql_data(
         that a request may take, 60 by default), SPARQL_MAX_RETRIES (the number of
         times a failed request is retried, 3 by default) and SPARQL_MAX_CONCURRENCY
         (the number of 'single_column' queries that may be posted at once, 1 - i.e.
-        sequential - by default). A variable whose query keeps failing after these
-        retries are exhausted is skipped, and reported as such, so that it does not
-        keep the rest of a 'single_column' extraction from being collected.
+        sequential - by default). A variable whose query keeps failing for a
+        transient reason after these retries are exhausted is skipped, and reported
+        as such, so that it does not keep the rest of a 'single_column' extraction
+        from being collected; a variable that the endpoint rejects outright (an
+        invalid or malformed variable, for instance) is not transient, however, and
+        aborts the whole extraction immediately instead.
     """
     # Retrieve environment variables - prioritise them over defaults as local setups might e.g. have different endpoints
     endpoint = get_env_var("SPARQL_ENDPOINT", endpoint)
@@ -787,6 +790,15 @@ def collect_sparql_data(
         failed_variables = []
         for variable, result_df, error in _execute_concurrently(tasks, max_concurrency):
             if error is not None:
+                if isinstance(error, UserInputError):
+                    # A UserInputError reflects a problem with the request itself -
+                    # an invalid or malformed variable, for instance - rather than a
+                    # transient failure of the endpoint; retrying it would not have
+                    # changed the outcome, and neither would querying the remaining
+                    # variables, so the whole extraction aborts immediately instead
+                    # of silently skipping the variable that raised it
+                    raise UserInputError(f"Error processing {variable}: {error}")
+
                 failed_variables.append(variable)
                 safe_log(
                     "error",

--- a/src/vantage6_strongaya_rdf/sparql_client.py
+++ b/src/vantage6_strongaya_rdf/sparql_client.py
@@ -15,7 +15,7 @@ import requests  # type: ignore
 from io import StringIO
 from typing import Any, Dict, List, Union, Optional
 
-from vantage6.algorithm.tools.exceptions import AlgorithmError
+from vantage6.algorithm.tools.exceptions import AlgorithmError, UserInputError
 from vantage6.algorithm.tools.util import get_env_var
 from vantage6_strongaya_general.miscellaneous import safe_log
 
@@ -50,7 +50,8 @@ def post_sparql_query(
     number of times only, so that a persistently failing endpoint eventually surfaces
     as an error rather than being retried forever. A status code that reflects a
     problem with the request itself (a 4xx status code) is not retried, as retrying it
-    would not change the outcome.
+    would not change the outcome, and is raised as a UserInputError rather than an
+    AlgorithmError, so that a caller can tell the two kinds of failure apart.
 
     Args:
         endpoint (str): The URL of the endpoint to send the request to.
@@ -103,6 +104,15 @@ def post_sparql_query(
 
         if response.status_code == 200:
             break
+
+        if 400 <= response.status_code < 500:
+            # A client error reflects a problem with the request itself - a malformed
+            # query, for instance - which a second attempt would only repeat, so it is
+            # raised immediately rather than retried
+            raise UserInputError(
+                f"{label} failed with status code {response.status_code}: "
+                f"{response.text}"
+            )
 
         if response.status_code in RETRYABLE_STATUS_CODES and not is_last_attempt:
             _wait_before_retry(

--- a/src/vantage6_strongaya_rdf/sparql_client.py
+++ b/src/vantage6_strongaya_rdf/sparql_client.py
@@ -9,12 +9,27 @@ File organisation:
 
 import csv
 import json
+import time
 import requests  # type: ignore
 
 from io import StringIO
 from typing import Any, Dict, List, Union, Optional
 
 from vantage6.algorithm.tools.exceptions import AlgorithmError
+from vantage6.algorithm.tools.util import get_env_var
+from vantage6_strongaya_general.miscellaneous import safe_log
+
+# The number of seconds that a request may take before it is considered to have
+# failed; deliberately kept a bit on the generous side, as an RDF-store can take a
+# while to answer a query over a large graph
+DEFAULT_TIMEOUT = 60
+
+# The number of times that a failed request is retried before it is given up on
+DEFAULT_MAX_RETRIES = 3
+
+# HTTP status codes that reflect a transient failure of the endpoint rather than a
+# problem with the request itself, and are therefore worth retrying
+RETRYABLE_STATUS_CODES = {500, 502, 503, 504}
 
 
 def post_sparql_query(
@@ -22,15 +37,37 @@ def post_sparql_query(
     query: str,
     request_type: str = "query",
     headers: Optional[Dict[str, str]] = None,
+    timeout: Optional[float] = None,
+    max_retries: Optional[int] = None,
+    log_label: Optional[str] = None,
 ) -> Union[str, List[Dict[str, Any]], Dict[Any, Any]]:
     """
     Send a POST request to the specified endpoint with the given query.
+
+    A request that cannot reach the endpoint at all (a connection error or a timeout)
+    or that receives a server error (a 5xx status code) is retried, with an
+    exponentially increasing delay between attempts; a request is retried a limited
+    number of times only, so that a persistently failing endpoint eventually surfaces
+    as an error rather than being retried forever. A status code that reflects a
+    problem with the request itself (a 4xx status code) is not retried, as retrying it
+    would not change the outcome.
 
     Args:
         endpoint (str): The URL of the endpoint to send the request to.
         query (str): The SPARQL query to send in the request body.
         request_type (str, optional): The type of request to send. Defaults to "query".
         headers (dict, optional): Any additional headers to include in the request.
+        timeout (float, optional): The number of seconds that the request may take
+                                   before it is considered to have failed. A value
+                                   specified in the environment variables will be
+                                   prioritised. Defaults to 60 seconds.
+        max_retries (int, optional): The maximum number of times that a failed request
+                                     is retried. A value specified in the environment
+                                     variables will be prioritised. Defaults to 3.
+        log_label (str, optional): A label that identifies the request within the log,
+                                   used to make retries and failures traceable back to
+                                   the query that caused them. Defaults to a generic
+                                   label when not provided.
 
     Returns:
         Union[str, List[Dict[str, Any]], Dict[Any, Any]]: The server's response to the request.
@@ -38,11 +75,53 @@ def post_sparql_query(
     if headers is None:
         headers = {"Content-Type": "application/x-www-form-urlencoded"}
     data = {request_type: query}
-    response = requests.post(endpoint, data=data, headers=headers)
-    if response.status_code != 200:
-        raise AlgorithmError(
-            f"SPARQL request failed with status code {response.status_code}."
+
+    if timeout is None:
+        timeout = get_env_var("SPARQL_TIMEOUT", DEFAULT_TIMEOUT, as_type="int")
+    if max_retries is None:
+        max_retries = get_env_var(
+            "SPARQL_MAX_RETRIES", DEFAULT_MAX_RETRIES, as_type="int"
         )
+
+    label = log_label or "SPARQL request"
+    response = None
+
+    for attempt in range(max_retries + 1):
+        is_last_attempt = attempt == max_retries
+        try:
+            response = requests.post(
+                endpoint, data=data, headers=headers, timeout=timeout
+            )
+        except (requests.exceptions.ConnectionError, requests.exceptions.Timeout) as e:
+            if is_last_attempt:
+                raise AlgorithmError(
+                    f"{label} could not reach {endpoint} after {max_retries + 1} "
+                    f"attempt(s): {e}."
+                )
+            _wait_before_retry(label, endpoint, attempt, max_retries, str(e))
+            continue
+
+        if response.status_code == 200:
+            break
+
+        if response.status_code in RETRYABLE_STATUS_CODES and not is_last_attempt:
+            _wait_before_retry(
+                label,
+                endpoint,
+                attempt,
+                max_retries,
+                f"status code {response.status_code}",
+            )
+            continue
+
+        raise AlgorithmError(
+            f"{label} failed with status code {response.status_code} after "
+            f"{attempt + 1} attempt(s)."
+        )
+
+    # A successful response always breaks out of the loop above, so this point is
+    # only reached once one has been received
+    assert response is not None
 
     try:
         return json.loads(response.text)
@@ -53,5 +132,31 @@ def post_sparql_query(
             return list(reader)
         except Exception as e:
             raise AlgorithmError(
-                f"SPARQL request did not return a valid JSON or CSV, error: {e}.",
+                f"{label} did not return a valid JSON or CSV, error: {e}.",
             )
+
+
+def _wait_before_retry(
+    label: str, endpoint: str, attempt: int, max_retries: int, reason: str
+) -> None:
+    """
+    Report a retryable failure and wait before the next attempt is made.
+
+    The delay doubles with every attempt (1s, 2s, 4s, ...), which spreads the retries
+    of a widely used endpoint out over time instead of hammering it with attempts in
+    quick succession.
+
+    Args:
+        label (str): A label that identifies the request within the log.
+        endpoint (str): The endpoint that the request was sent to.
+        attempt (int): The (zero-based) attempt that failed.
+        max_retries (int): The maximum number of retries that are attempted.
+        reason (str): A description of why the attempt failed.
+    """
+    backoff_seconds = 2**attempt
+    safe_log(
+        "warn",
+        f"{label} failed against {endpoint} ({reason}); attempt {attempt + 1} of "
+        f"{max_retries + 1}, retrying in {backoff_seconds}s.",
+    )
+    time.sleep(backoff_seconds)

--- a/tests/unit/test_library_functions.py
+++ b/tests/unit/test_library_functions.py
@@ -124,9 +124,12 @@ class TestSparqlClient:
         # This should handle gracefully and not crash
         query = "SELECT ?s ?p ?o WHERE { ?s ?p ?o . } LIMIT 1"
 
-        # Test with invalid endpoint should return None or raise appropriate exception
+        # Retries are turned off, as this test is about the failure itself rather
+        # than about the retry behaviour, which is covered separately
         try:
-            result = post_sparql_query("http://invalid-endpoint:9999/sparql", query)
+            result = post_sparql_query(
+                "http://invalid-endpoint:9999/sparql", query, max_retries=0
+            )
             # If it doesn't raise an exception, result should be None or empty
             assert result is None or result == []
         except Exception as e:


### PR DESCRIPTION
This PR allows that node administrators configure various SPARQL request related attributes to prevent that endpoints with a lot of data get overloaded when the endpoint itself cannot handle it (though they should consider switching GraphDB for RDF4J, but nonetheless valuable to allow configuration of these depending on hardware specs)